### PR TITLE
Implement basic Stonewall Firefox addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # stonewall-firefox
-this is a firefox addon to stop doom scrolling.
+
+Stonewall is a Firefox add-on designed to help you avoid distracting websites. It can:
+
+- Block websites or specific paths.
+- Track the time you spend on each domain.
+- Schedule when blocked rules are active.
+- Quickly block the current page from the context menu.
+
+## Installing
+
+1. Open Firefox and browse to `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on** and select the `manifest.json` file inside the `extension` directory.
+
+## Options
+
+Open the add-on options to add or remove blocked sites and configure optional start/end times.
+
+Blocked entries use the full URL path. For example, blocking `https://www.reddit.com/r/gaming` leaves other Reddit paths accessible.
+
+Time spent on each domain is stored locally and updated once per second.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,79 @@
+let blockedList = [];
+let timeSpent = {};
+let currentDomain = null;
+
+async function loadData() {
+  const data = await browser.storage.local.get({blocked: [], timeSpent: {}});
+  blockedList = data.blocked;
+  timeSpent = data.timeSpent;
+}
+
+loadData();
+
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local') {
+    if (changes.blocked) blockedList = changes.blocked.newValue;
+    if (changes.timeSpent) timeSpent = changes.timeSpent.newValue;
+  }
+});
+
+function inSchedule(entry) {
+  if (!entry.start || !entry.end) return true;
+  const now = new Date();
+  const minutes = now.getHours() * 60 + now.getMinutes();
+  const [sh, sm] = entry.start.split(':').map(Number);
+  const [eh, em] = entry.end.split(':').map(Number);
+  const startM = sh * 60 + sm;
+  const endM = eh * 60 + em;
+  if (startM <= endM) {
+    return minutes >= startM && minutes <= endM;
+  } else {
+    return minutes >= startM || minutes <= endM;
+  }
+}
+
+function isBlocked(url) {
+  for (const entry of blockedList) {
+    if (url.startsWith(entry.pattern)) {
+      if (inSchedule(entry)) return true;
+    }
+  }
+  return false;
+}
+
+browser.webNavigation.onCommitted.addListener((details) => {
+  if (isBlocked(details.url)) {
+    browser.tabs.update(details.tabId, {url: 'about:blank'});
+  }
+});
+
+browser.contextMenus.create({
+  id: 'stonewall-block',
+  title: 'Block this page',
+  contexts: ['page']
+});
+
+async function addBlock(url) {
+  const data = await browser.storage.local.get({blocked: []});
+  data.blocked.push({pattern: url, start: null, end: null});
+  await browser.storage.local.set({blocked: data.blocked});
+}
+
+browser.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === 'stonewall-block' && tab) {
+    addBlock(tab.url);
+  }
+});
+
+setInterval(async () => {
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
+  if (!tabs[0] || !tabs[0].url.startsWith('http')) return;
+  const domain = new URL(tabs[0].url).hostname;
+  if (currentDomain === null) currentDomain = domain;
+  if (domain === currentDomain) {
+    timeSpent[domain] = (timeSpent[domain] || 0) + 1;
+  } else {
+    currentDomain = domain;
+  }
+  await browser.storage.local.set({timeSpent});
+}, 1000);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 2,
+  "name": "Stonewall",
+  "version": "0.1.0",
+  "description": "Block distracting websites, track time, and schedule blocks.",
+  "permissions": [
+    "storage",
+    "tabs",
+    "contextMenus",
+    "webNavigation",
+    "alarms"
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+  "applications": {
+    "gecko": {
+      "id": "stonewall@example.com"
+    }
+  }
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Stonewall Options</title>
+</head>
+<body>
+  <h1>Stonewall Options</h1>
+  <form id="addForm">
+    <input id="pattern" type="text" placeholder="URL pattern" required>
+    <input id="start" type="time">
+    <input id="end" type="time">
+    <button type="submit">Add</button>
+  </form>
+  <ul id="blockedList"></ul>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,40 @@
+async function load() {
+  const data = await browser.storage.local.get({blocked: []});
+  updateUI(data.blocked);
+}
+
+function updateUI(list) {
+  const ul = document.getElementById('blockedList');
+  ul.innerHTML = '';
+  list.forEach((entry, index) => {
+    const li = document.createElement('li');
+    const text = entry.pattern + (entry.start ? ` (${entry.start}-${entry.end})` : '');
+    li.textContent = text + ' ';
+    const btn = document.createElement('button');
+    btn.textContent = 'Remove';
+    btn.addEventListener('click', async () => {
+      list.splice(index, 1);
+      await browser.storage.local.set({blocked: list});
+      load();
+    });
+    li.appendChild(btn);
+    ul.appendChild(li);
+  });
+}
+
+document.getElementById('addForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const pattern = document.getElementById('pattern').value.trim();
+  const start = document.getElementById('start').value;
+  const end = document.getElementById('end').value;
+  if (!pattern) return;
+  const data = await browser.storage.local.get({blocked: []});
+  data.blocked.push({pattern, start: start || null, end: end || null});
+  await browser.storage.local.set({blocked: data.blocked});
+  document.getElementById('pattern').value = '';
+  document.getElementById('start').value = '';
+  document.getElementById('end').value = '';
+  load();
+});
+
+load();


### PR DESCRIPTION
## Summary
- add addon manifest and scripts under `extension`
- implement blocking, time tracking and context menu functionality
- provide simple options page for editing blocked sites
- update README with usage notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68543d7948c88328b717819e08b0ffc9