### PR TITLE
Add pomodoro timer and schedule editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Stonewall is a Firefox add-on designed to help you avoid distracting websites. I
 ## Options
 
 Open the add-on options to add or remove blocked sites and configure optional start/end times.
+You can adjust the schedule of existing entries right from the list and start a temporary Pomodoro block for a site.
 The options page also displays how much time you've spent on each domain so far.
 
 Blocked entries use the full URL path. For example, blocking `https://www.reddit.com/r/gaming` leaves other Reddit paths accessible.

--- a/extension/background.js
+++ b/extension/background.js
@@ -2,6 +2,15 @@ let blockedList = [];
 let timeSpent = {};
 let currentDomain = null;
 
+async function cleanPomodoro() {
+  const now = Date.now();
+  const newList = blockedList.filter(e => !(e.pomodoro && now >= e.until));
+  if (newList.length !== blockedList.length) {
+    blockedList = newList;
+    await browser.storage.local.set({blocked: blockedList});
+  }
+}
+
 async function loadData() {
   const data = await browser.storage.local.get({blocked: [], timeSpent: {}});
   blockedList = data.blocked;
@@ -33,8 +42,11 @@ function inSchedule(entry) {
 }
 
 function isBlocked(url) {
+  const now = Date.now();
   for (const entry of blockedList) {
+    if (entry.pomodoro && now >= entry.until) continue;
     if (url.startsWith(entry.pattern)) {
+      if (entry.pomodoro) return true;
       if (inSchedule(entry)) return true;
     }
   }
@@ -76,4 +88,5 @@ setInterval(async () => {
     currentDomain = domain;
   }
   await browser.storage.local.set({timeSpent});
+  await cleanPomodoro();
 }, 1000);

--- a/extension/options.html
+++ b/extension/options.html
@@ -8,9 +8,18 @@
   <h1>Stonewall Options</h1>
   <form id="addForm">
     <input id="pattern" type="text" placeholder="URL pattern" required>
+    <label for="start">Start time</label>
     <input id="start" type="time">
+    <label for="end">End time</label>
     <input id="end" type="time">
     <button type="submit">Add</button>
+  </form>
+
+  <h2>Pomodoro Block</h2>
+  <form id="pomodoroForm">
+    <input id="pomodoroPattern" type="text" placeholder="URL pattern" required>
+    <input id="pomodoroMinutes" type="number" min="1" placeholder="Minutes" required>
+    <button type="submit">Start</button>
   </form>
   <ul id="blockedList"></ul>
   <h2>Time Spent</h2>

--- a/extension/options.js
+++ b/extension/options.js
@@ -8,10 +8,38 @@ async function load() {
 function updateUI(list) {
   const ul = document.getElementById('blockedList');
   ul.innerHTML = '';
+  const now = Date.now();
   list.forEach((entry, index) => {
     const li = document.createElement('li');
-    const text = entry.pattern + (entry.start ? ` (${entry.start}-${entry.end})` : '');
-    li.textContent = text + ' ';
+    const info = document.createElement('span');
+    if (entry.pomodoro) {
+      const mins = Math.max(0, Math.ceil((entry.until - now) / 60000));
+      info.textContent = `${entry.pattern} (Pomodoro ${mins}m left) `;
+    } else {
+      info.textContent = `${entry.pattern} `;
+    }
+    li.appendChild(info);
+
+    if (!entry.pomodoro) {
+      const startInput = document.createElement('input');
+      startInput.type = 'time';
+      startInput.value = entry.start || '';
+      const endInput = document.createElement('input');
+      endInput.type = 'time';
+      endInput.value = entry.end || '';
+      const saveBtn = document.createElement('button');
+      saveBtn.textContent = 'Save';
+      saveBtn.addEventListener('click', async () => {
+        list[index].start = startInput.value || null;
+        list[index].end = endInput.value || null;
+        await browser.storage.local.set({blocked: list});
+        load();
+      });
+      li.appendChild(startInput);
+      li.appendChild(endInput);
+      li.appendChild(saveBtn);
+    }
+
     const btn = document.createElement('button');
     btn.textContent = 'Remove';
     btn.addEventListener('click', async () => {
@@ -58,6 +86,20 @@ document.getElementById('addForm').addEventListener('submit', async (e) => {
   document.getElementById('pattern').value = '';
   document.getElementById('start').value = '';
   document.getElementById('end').value = '';
+  load();
+});
+
+document.getElementById('pomodoroForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const pattern = document.getElementById('pomodoroPattern').value.trim();
+  const minutes = parseInt(document.getElementById('pomodoroMinutes').value, 10);
+  if (!pattern || isNaN(minutes) || minutes <= 0) return;
+  const until = Date.now() + minutes * 60000;
+  const data = await browser.storage.local.get({blocked: []});
+  data.blocked.push({pattern, pomodoro: true, until});
+  await browser.storage.local.set({blocked: data.blocked});
+  document.getElementById('pomodoroPattern').value = '';
+  document.getElementById('pomodoroMinutes').value = '';
   load();
 });
 


### PR DESCRIPTION
## Summary
- add labels for start and end times in the options page
- allow starting a temporary Pomodoro block
- let schedules be edited directly in the block list
- persist Pomodoro blocks and clear them when finished

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685444938ffc8328919f0549653650f9