### PR TITLE
Add list-based blocking with schedules

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,37 +1,27 @@
-let blockedList = [];
+let lists = [];
 let timeSpent = {};
 let currentDomain = null;
 
 async function cleanPomodoro() {
   const now = Date.now();
-  const newList = blockedList.filter(e => !(e.pomodoro && now >= e.until));
-  if (newList.length !== blockedList.length) {
-    blockedList = newList;
-    await browser.storage.local.set({blocked: blockedList});
+  let changed = false;
+  for (const list of lists) {
+    if (list.pomodoro && now >= list.pomodoro.until) {
+      list.pomodoro = null;
+      changed = true;
+    }
+  }
+  if (changed) {
+    await browser.storage.local.set({lists});
   }
 }
 
-async function loadData() {
-  const data = await browser.storage.local.get({blocked: [], timeSpent: {}});
-  blockedList = data.blocked;
-  timeSpent = data.timeSpent;
-}
-
-loadData();
-
-browser.storage.onChanged.addListener((changes, area) => {
-  if (area === 'local') {
-    if (changes.blocked) blockedList = changes.blocked.newValue;
-    if (changes.timeSpent) timeSpent = changes.timeSpent.newValue;
-  }
-});
-
-function inSchedule(entry) {
-  if (!entry.start || !entry.end) return true;
+function inSchedule(list) {
+  if (!list.start || !list.end) return true;
   const now = new Date();
   const minutes = now.getHours() * 60 + now.getMinutes();
-  const [sh, sm] = entry.start.split(':').map(Number);
-  const [eh, em] = entry.end.split(':').map(Number);
+  const [sh, sm] = list.start.split(':').map(Number);
+  const [eh, em] = list.end.split(':').map(Number);
   const startM = sh * 60 + sm;
   const endM = eh * 60 + em;
   if (startM <= endM) {
@@ -41,17 +31,55 @@ function inSchedule(entry) {
   }
 }
 
+function listActive(list) {
+  if (list.pomodoro) return Date.now() < list.pomodoro.until;
+  return inSchedule(list);
+}
+
+function matches(list, url) {
+  return list.patterns.some(p => url.startsWith(p));
+}
+
 function isBlocked(url) {
-  const now = Date.now();
-  for (const entry of blockedList) {
-    if (entry.pomodoro && now >= entry.until) continue;
-    if (url.startsWith(entry.pattern)) {
-      if (entry.pomodoro) return true;
-      if (inSchedule(entry)) return true;
+  const activeAllows = lists.filter(l => l.type === 'allow' && listActive(l));
+  if (activeAllows.length) {
+    const allowed = activeAllows.some(l => matches(l, url));
+    if (!allowed) return true;
+  }
+  for (const list of lists) {
+    if (list.type === 'block' && listActive(list) && matches(list, url)) {
+      return true;
     }
   }
   return false;
 }
+
+async function loadData() {
+  const data = await browser.storage.local.get({lists: null, blocked: [], timeSpent: {}});
+  if (!data.lists) {
+    data.lists = [{
+      id: Date.now(),
+      name: 'Default Block',
+      type: 'block',
+      patterns: data.blocked.map(e => e.pattern),
+      start: null,
+      end: null,
+      pomodoro: null
+    }];
+    await browser.storage.local.set({lists: data.lists, blocked: []});
+  }
+  lists = data.lists;
+  timeSpent = data.timeSpent;
+}
+
+loadData();
+
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local') {
+    if (changes.lists) lists = changes.lists.newValue;
+    if (changes.timeSpent) timeSpent = changes.timeSpent.newValue;
+  }
+});
 
 browser.webNavigation.onCommitted.addListener((details) => {
   if (isBlocked(details.url)) {
@@ -70,9 +98,15 @@ browser.contextMenus.create({
 });
 
 async function addBlock(url) {
-  const data = await browser.storage.local.get({blocked: []});
-  data.blocked.push({pattern: url, start: null, end: null});
-  await browser.storage.local.set({blocked: data.blocked});
+  const data = await browser.storage.local.get({lists: []});
+  if (data.lists.length === 0) {
+    data.lists.push({id: Date.now(), name: 'Default Block', type: 'block', patterns: [], start: null, end: null, pomodoro: null});
+  }
+  const list = data.lists[0];
+  if (!list.patterns.includes(url)) {
+    list.patterns.push(url);
+  }
+  await browser.storage.local.set({lists: data.lists});
 }
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/extension/options.html
+++ b/extension/options.html
@@ -3,27 +3,52 @@
 <head>
   <meta charset="utf-8">
   <title>Stonewall Options</title>
+  <style>
+    table { border-collapse: collapse; }
+    td, th { border: 1px solid #ccc; padding: 4px 8px; }
+    input[type="text"] { width: 100%; }
+  </style>
 </head>
 <body>
   <h1>Stonewall Options</h1>
-  <form id="addForm">
-    <input id="pattern" type="text" placeholder="URL pattern" required>
-    <label for="start">Start time</label>
-    <input id="start" type="time">
-    <label for="end">End time</label>
-    <input id="end" type="time">
+  <div id="listSelector">
+    <label for="lists">Select List:</label>
+    <select id="lists"></select>
+    <button id="addListBtn">Add List</button>
+  </div>
+  <div id="listSettings">
+    <label>Name <input id="listName" type="text"></label>
+    <label>Type
+      <select id="listType">
+        <option value="block">Block</option>
+        <option value="allow">Allow Only</option>
+      </select>
+    </label>
+    <label for="listStart">Start time</label>
+    <input id="listStart" type="time">
+    <label for="listEnd">End time</label>
+    <input id="listEnd" type="time">
+    <button id="saveListSettings">Save Settings</button>
+    <h2>Pomodoro</h2>
+    <input id="pomodoroMinutes" type="number" min="1" placeholder="Minutes">
+    <button id="startPomodoro">Start</button>
+  </div>
+
+  <h2>Patterns</h2>
+  <table id="patternsTable">
+    <thead><tr><th>URL Pattern</th><th>Actions</th></tr></thead>
+    <tbody></tbody>
+  </table>
+  <form id="addPatternForm">
+    <input id="newPattern" type="text" placeholder="URL pattern" required>
     <button type="submit">Add</button>
   </form>
 
-  <h2>Pomodoro Block</h2>
-  <form id="pomodoroForm">
-    <input id="pomodoroPattern" type="text" placeholder="URL pattern" required>
-    <input id="pomodoroMinutes" type="number" min="1" placeholder="Minutes" required>
-    <button type="submit">Start</button>
-  </form>
-  <ul id="blockedList"></ul>
   <h2>Time Spent</h2>
-  <ul id="statsList"></ul>
+  <table>
+    <thead><tr><th>Domain</th><th>Time</th><th></th></tr></thead>
+    <tbody id="statsList"></tbody>
+  </table>
 
   <script src="options.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- redesign options page to manage multiple lists
- allow lists to be Block or Allow Only
- move schedules to list level and add pomodoro timer for lists
- use tables for patterns and stats for better readability
- update background script to work with list-based storage

## Testing
- `node --check extension/options.js`
- `node --check extension/background.js`


------
https://chatgpt.com/codex/tasks/task_e_68546728eb548328a5fe08189f25e2d2