### PR TITLE
Add inline editing to options

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -32,11 +32,12 @@
     <h2>Pomodoro</h2>
     <input id="pomodoroMinutes" type="number" min="1" placeholder="Minutes">
     <button id="startPomodoro">Start</button>
+    <span id="pomodoroCountdown"></span>
   </div>
 
   <h2>Patterns</h2>
   <table id="patternsTable">
-    <thead><tr><th>URL Pattern</th><th>Actions</th></tr></thead>
+    <thead><tr><th>URL Pattern</th><th>Remove</th></tr></thead>
     <tbody></tbody>
   </table>
   <form id="addPatternForm">


### PR DESCRIPTION
## Summary
- update patterns table to save changes on blur/enter
- auto-save list name, type and schedule fields
- rename pattern table header
- fix blank pattern causing universal blocking
- display live pomodoro countdown

## Testing
- `node --check extension/options.js`
- `node --check extension/background.js`


------
https://chatgpt.com/codex/tasks/task_e_68546dca7ccc832886a56077e8fb739d