### PR TITLE
Improve allow-only behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ You can remove domains from this list to reset their counters.
 Blocked entries use the full URL path. For example, blocking `https://www.reddit.com/r/gaming` leaves other Reddit paths accessible.
 
 Time spent on each domain is stored locally and updated once per second.
+When a list's type is set to "Allow Only", any active allow lists restrict access exclusively to their patterns. All other URLs are blocked, and these allowances take priority over block lists.
+Extension and about pages are automatically allowed so you can always access add-on options.
+Blocked URLs show a page with an Unblock button that either removes the address from a block list or adds it to an active allow list.

--- a/extension/blocked.html
+++ b/extension/blocked.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>URL Blocked</title>
+</head>
+<body>
+  <p id="msg"></p>
+  <button id="unblock">Unblock</button>
+  <script src="blocked.js"></script>
+</body>
+</html>

--- a/extension/blocked.js
+++ b/extension/blocked.js
@@ -1,0 +1,8 @@
+const params = new URLSearchParams(location.search);
+const url = params.get('url') || '';
+document.getElementById('msg').textContent = `The following URL is blocked: ${url}`;
+
+document.getElementById('unblock').addEventListener('click', () => {
+  browser.runtime.sendMessage({type: 'unblockUrl', url});
+  window.history.back();
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,6 +21,9 @@
     "page": "options.html",
     "open_in_tab": true
   },
+  "web_accessible_resources": [
+    "blocked.html"
+  ],
   "applications": {
     "gecko": {
       "id": "stonewall@example.com"


### PR DESCRIPTION
## Summary
- make allow lists override block lists
- document allow-only behavior in README
- do not block extension pages when allow lists are active
- show custom blocked page with option to unblock URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68547622a3148328be355d3a8e0f6414