### PR TITLE
Improve blocking and auto-save list names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Stonewall is a Firefox add-on designed to help you avoid distracting websites. I
 - Clear time spent data for specific domains.
 - Schedule when blocked rules are active.
 - Quickly block the current page from the context menu.
+- Reliably cancel requests before they are loaded.
 
 ## Installing
 
@@ -19,6 +20,8 @@ Open the add-on options to add or remove blocked sites and configure optional st
 You can adjust the schedule of existing entries right from the list and start a temporary Pomodoro block for a site.
 The options page also displays how much time you've spent on each domain so far.
 You can remove domains from this list to reset their counters.
+
+Version 0.1.1 adds a web request listener to stop blocked pages before they load.
 
 Blocked entries use the full URL path. For example, blocking `https://www.reddit.com/r/gaming` leaves other Reddit paths accessible.
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -99,11 +99,12 @@ browser.storage.onChanged.addListener((changes, area) => {
   }
 });
 
-browser.webNavigation.onCommitted.addListener((details) => {
-  if (isBlocked(details.url)) {
-    browser.tabs.update(details.tabId, {url: 'about:blank'});
-  }
-});
+
+browser.webRequest.onBeforeRequest.addListener(
+  (details) => ({ cancel: isBlocked(details.url) }),
+  { urls: ["<all_urls>"], types: ["main_frame"] },
+  ["blocking"]
+);
 
 browser.contextMenus.create({
   id: 'stonewall-block',

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,13 +1,15 @@
 {
   "manifest_version": 2,
   "name": "Stonewall",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Block distracting websites, track time, and schedule blocks.",
   "permissions": [
     "storage",
     "tabs",
     "contextMenus",
     "webNavigation",
+    "webRequest",
+    "webRequestBlocking",
     "alarms"
   ],
   "background": {

--- a/extension/options.js
+++ b/extension/options.js
@@ -142,6 +142,7 @@ function saveCurrentListFields() {
 document.getElementById('saveListSettings').addEventListener('click', saveCurrentListFields);
 
 listNameEl.addEventListener('blur', saveCurrentListFields);
+listNameEl.addEventListener('input', saveCurrentListFields);
 listTypeEl.addEventListener('change', saveCurrentListFields);
 listStartEl.addEventListener('change', saveCurrentListFields);
 listEndEl.addEventListener('change', saveCurrentListFields);


### PR DESCRIPTION
## Summary
- add webRequest permissions and listener for better blocking
- bump version to 0.1.1
- auto-save list name while typing
- document new blocking method

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68583dfa3fb08328b6f756c7e415e5a0