### PR TITLE
Rewrite extension with focus sessions and breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,17 @@
 # stonewall-firefox
 
-Stonewall is a Firefox add-on designed to help you avoid distracting websites. It can:
-
-- Block websites or specific paths.
-- Track the time you spend on each domain.
-- Clear time spent data for specific domains.
-- Schedule when blocked rules are active.
-- Quickly block the current page from the context menu.
-- Reliably cancel requests before they are loaded.
+Stonewall is a minimal browser extension for blocking distracting websites. It supports schedules with optional breaks, immediate blocking, and the ability to block or allow specific pages.
 
 ## Installing
+1. Open Firefox and navigate to `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on** and select `manifest.json` in the `extension` folder.
 
-1. Open Firefox and browse to `about:debugging#/runtime/this-firefox`.
-2. Click **Load Temporary Add-on** and select the `manifest.json` file inside the `extension` directory.
+## Usage
+Open the extension options page to configure blocking rules.
 
-## Options
+- **Mode** – choose between blocking listed URLs or allowing only the listed URLs.
+- **Immediate Block** – manually enable or disable blocking regardless of schedules.
+- **Patterns** – list of full URLs or domains to block or allow.
+- **Focus Sessions** – set days of the week, start and end times, and break lengths. When a session ends the break timer unblocks pages for the specified minutes.
 
-Open the add-on options to add or remove blocked sites and configure optional start/end times.
-You can adjust the schedule of existing entries right from the list and start a temporary Pomodoro block for a site. A small popup is available from the toolbar button where you can select a list and begin or end a Pomodoro session without opening the options page. The popup also links to the preferences page for quick access. Each list shows a status indicator with a manual Block/Unblock switch. The status updates automatically based on schedules and Pomodoro sessions but lets you override it at any time.
-Both the popup and options pages pre-fill the Pomodoro timer with a 20-minute value so you can simply press **Start** for a standard session.
-The options page also displays how much time you've spent on each domain so far.
-You can remove domains from this list to reset their counters.
-
-Version 0.1.1 adds a web request listener to stop blocked pages before they load.
-
-Blocked entries use the full URL path. For example, blocking `https://www.reddit.com/r/gaming` leaves other Reddit paths accessible.
-
-Time spent on each domain is stored locally and updated once per second.
-Only one list is active at a time. Choose the active list from the toolbar popup or the options page. If the active list is set to "Allow Only" then any URL not matching one of its patterns is blocked. Extension and about pages remain accessible regardless of which list is active.
-Blocked URLs show a page with an Unblock button that either removes the address from a block list or adds it to the active allow list.
+Use the toolbar popup to quickly toggle immediate blocking or open the options page.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,42 +1,23 @@
-let lists = [];
-let timeSpent = {};
-let currentDomain = null;
-let activeListId = null;
+'use strict';
 
-async function cleanPomodoro() {
-  const now = Date.now();
-  let changed = false;
-  for (const list of lists) {
-    if (list.pomodoro && now >= list.pomodoro.until) {
-      list.pomodoro = null;
-      changed = true;
-    }
-  }
-  if (changed) {
-    await browser.storage.local.set({lists});
-  }
+// Storage keys
+const DEFAULT_STATE = {
+  mode: 'block', // 'block' or 'allow'
+  patterns: [], // list of URL patterns
+  sessions: [], // [{days:[0-6], start:'HH:MM', end:'HH:MM', break:5}]
+  immediate: false, // manual immediate block
+  breakUntil: 0
+};
+
+let state = Object.assign({}, DEFAULT_STATE);
+
+async function loadState() {
+  const data = await browser.storage.local.get(Object.keys(DEFAULT_STATE));
+  state = Object.assign({}, DEFAULT_STATE, data);
 }
 
-function inSchedule(list) {
-  if (!list.start || !list.end) return true;
-  const now = new Date();
-  const minutes = now.getHours() * 60 + now.getMinutes();
-  const [sh, sm] = list.start.split(':').map(Number);
-  const [eh, em] = list.end.split(':').map(Number);
-  const startM = sh * 60 + sm;
-  const endM = eh * 60 + em;
-  if (startM <= endM) {
-    return minutes >= startM && minutes <= endM;
-  } else {
-    return minutes >= startM || minutes <= endM;
-  }
-}
-
-function listActive(list) {
-  if (list.manual === 'block') return true;
-  if (list.manual === 'unblock') return false;
-  if (list.pomodoro) return Date.now() < list.pomodoro.until;
-  return inSchedule(list);
+function saveState() {
+  return browser.storage.local.set(state);
 }
 
 function patternMatches(pattern, url) {
@@ -52,131 +33,98 @@ function patternMatches(pattern, url) {
       return u.pathname.startsWith(path);
     }
   } catch (e) {
-    // ignore malformed URLs
+    // ignore
   }
   return false;
 }
 
-function matches(list, url) {
-  return list.patterns.some(p => patternMatches(p, url));
+function withinSession(session) {
+  const now = new Date();
+  if (!session.days.includes(now.getDay())) return false;
+  const [sh, sm] = session.start.split(':').map(Number);
+  const [eh, em] = session.end.split(':').map(Number);
+  const startM = sh * 60 + sm;
+  const endM = eh * 60 + em;
+  const minutes = now.getHours() * 60 + now.getMinutes();
+  if (startM <= endM) return minutes >= startM && minutes < endM;
+  return minutes >= startM || minutes < endM;
+}
+
+function checkBreaks() {
+  const now = Date.now();
+  if (state.breakUntil && now >= state.breakUntil) {
+    state.breakUntil = 0;
+    saveState();
+  }
+  if (state.immediate || state.breakUntil) return;
+  for (const ses of state.sessions) {
+    const [eh, em] = ses.end.split(':').map(Number);
+    const end = new Date();
+    end.setHours(eh, em, 0, 0);
+    if (withinSession(ses)) return;
+    const diff = Date.now() - end.getTime();
+    if (diff >= 0 && diff < 60000) {
+      if (ses.break > 0) {
+        state.breakUntil = Date.now() + ses.break * 60000;
+        saveState();
+      }
+    }
+  }
+}
+
+function focusActive() {
+  if (state.immediate) return true;
+  if (state.breakUntil && Date.now() < state.breakUntil) return false;
+  return state.sessions.some(withinSession);
 }
 
 function isBlocked(url) {
   try {
     const scheme = new URL(url).protocol;
-    if (scheme !== 'http:' && scheme !== 'https:') {
-      return false;
-    }
+    if (scheme !== 'http:' && scheme !== 'https:') return false;
   } catch (e) {
     return false;
   }
-  const list = lists.find(l => l.id === activeListId);
-  if (!list || !listActive(list)) return false;
-  if (list.type === 'allow') {
-    return !matches(list, url);
-  }
-  return matches(list, url);
-
+  if (!focusActive()) return false;
+  const matched = state.patterns.some(p => patternMatches(p, url));
+  if (state.mode === 'block') return matched;
+  return !matched;
 }
 
-async function loadData() {
-  const data = await browser.storage.local.get({lists: null, blocked: [], timeSpent: {}, activeListId: null});
-
-  if (!data.lists) {
-    data.lists = [{
-      id: Date.now(),
-      name: 'Default Block',
-      type: 'block',
-      patterns: data.blocked.map(e => e.pattern),
-      start: null,
-      end: null,
-      pomodoro: null,
-      manual: null
-    }];
-    await browser.storage.local.set({lists: data.lists, blocked: []});
+browser.webNavigation.onCommitted.addListener(details => {
+  if (isBlocked(details.url)) {
+    const blockedUrl = browser.runtime.getURL('blocked.html') + '?url=' + encodeURIComponent(details.url);
+    browser.tabs.update(details.tabId, {url: blockedUrl});
   }
-  lists = data.lists.map(l => Object.assign({manual: null}, l));
-  timeSpent = data.timeSpent;
-  activeListId = data.activeListId !== null ? data.activeListId : lists[0].id;
-}
+});
 
-loadData();
+browser.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'unblockUrl' && msg.url) {
+    if (state.mode === 'allow') {
+      if (!state.patterns.includes(msg.url)) state.patterns.push(msg.url);
+    } else {
+      const idx = state.patterns.indexOf(msg.url);
+      if (idx !== -1) state.patterns.splice(idx, 1);
+    }
+    return saveState();
+  }
+  if (msg.type === 'unblock-now') {
+    state.immediate = false;
+    return saveState();
+  } else if (msg.type === 'block-now') {
+    state.immediate = true;
+    state.breakUntil = 0;
+    return saveState();
+  }
+});
 
 browser.storage.onChanged.addListener((changes, area) => {
   if (area === 'local') {
-    if (changes.lists) lists = changes.lists.newValue;
-    if (changes.timeSpent) timeSpent = changes.timeSpent.newValue;
-    if (changes.activeListId) activeListId = changes.activeListId.newValue;
+    for (const key of Object.keys(changes)) {
+      state[key] = changes[key].newValue;
+    }
   }
 });
 
-
-browser.webNavigation.onCommitted.addListener((details) => {
-  if (isBlocked(details.url)) {
-    const blockPage = browser.runtime.getURL('blocked.html') +
-      '?url=' + encodeURIComponent(details.url);
-    browser.tabs.update(details.tabId, {url: blockPage});
-  }
-});
-
-async function handleUnblock(url) {
-  const list = lists.find(l => l.id === activeListId);
-  if (!list) return;
-  if (list.type === 'allow') {
-    if (!list.patterns.includes(url)) list.patterns.push(url);
-  } else {
-    const idx = list.patterns.indexOf(url);
-    if (idx !== -1) list.patterns.splice(idx, 1);
-  }
-  await browser.storage.local.set({lists});
-}
-
-browser.runtime.onMessage.addListener((msg) => {
-  if (msg && msg.type === 'unblockUrl' && msg.url) {
-    handleUnblock(msg.url);
-  }
-});
-
-
-browser.contextMenus.create({
-  id: 'stonewall-block',
-  title: 'Block this page',
-  contexts: ['page'],
-  icons: {
-    16: 'trowel.png',
-    32: 'trowel.png'
-  }
-});
-
-async function addBlock(url) {
-  const data = await browser.storage.local.get({lists: [], activeListId: null});
-  if (data.lists.length === 0) {
-    data.lists.push({id: Date.now(), name: 'Default Block', type: 'block', patterns: [], start: null, end: null, pomodoro: null, manual: null});
-    data.activeListId = data.lists[0].id;
-  }
-  const list = data.lists.find(l => l.id === (data.activeListId || data.lists[0].id));
-  if (!list.patterns.includes(url)) {
-    list.patterns.push(url);
-  }
-  await browser.storage.local.set({lists: data.lists, activeListId: data.activeListId});
-}
-
-browser.contextMenus.onClicked.addListener((info, tab) => {
-  if (info.menuItemId === 'stonewall-block' && tab) {
-    addBlock(tab.url);
-  }
-});
-
-setInterval(async () => {
-  const tabs = await browser.tabs.query({active: true, currentWindow: true});
-  if (!tabs[0] || !tabs[0].url.startsWith('http')) return;
-  const domain = new URL(tabs[0].url).hostname;
-  if (currentDomain === null) currentDomain = domain;
-  if (domain === currentDomain) {
-    timeSpent[domain] = (timeSpent[domain] || 0) + 1;
-  } else {
-    currentDomain = domain;
-  }
-  await browser.storage.local.set({timeSpent});
-  await cleanPomodoro();
-}, 1000);
+loadState();
+setInterval(checkBreaks, 60000);

--- a/extension/options.html
+++ b/extension/options.html
@@ -6,62 +6,39 @@
   <style>
     table { border-collapse: collapse; }
     td, th { border: 1px solid #ccc; padding: 4px 8px; }
-    input[type="text"] { width: 100%; }
+    input[type="text"], input[type="time"] { width: 100%; }
   </style>
 </head>
 <body>
   <h1>Stonewall Options</h1>
-  <div id="listSelector">
-    <label for="lists">Select List:</label>
-    <select id="lists"></select>
-    <button id="addListBtn">Add List</button>
-    <button id="setActive">Set Active</button>
-
-  </div>
-  <div id="listSettings">
-    <label>Name <input id="listName" type="text"></label>
-    <label>Type
-      <select id="listType">
-        <option value="block">Block</option>
-        <option value="allow">Allow Only</option>
-      </select>
-    </label>
-    <label for="listStart">Start time</label>
-    <input id="listStart" type="time">
-    <label for="listEnd">End time</label>
-    <input id="listEnd" type="time">
-    <label>Manual
-      <select id="listManual">
-        <option value="">Auto</option>
-        <option value="block">Block</option>
-        <option value="unblock">Unblock</option>
-      </select>
-    </label>
-    <div>Status: <span id="listStatus"></span></div>
-    <button id="saveListSettings">Save Settings</button>
-    <h2>Pomodoro</h2>
-    <input id="pomodoroMinutes" type="number" min="1" value="20">
-
-    <button id="startPomodoro">Start</button>
-    <button id="endPomodoro">End</button>
-    <span id="pomodoroCountdown"></span>
-  </div>
+  <label>Mode
+    <select id="mode">
+      <option value="block">Block</option>
+      <option value="allow">Allow Only</option>
+    </select>
+  </label>
+  <label><input id="immediate" type="checkbox"> Immediate Block</label>
 
   <h2>Patterns</h2>
   <table id="patternsTable">
-    <thead><tr><th>URL Pattern</th><th>Remove</th></tr></thead>
+    <thead><tr><th>URL Pattern</th><th></th></tr></thead>
     <tbody></tbody>
   </table>
   <form id="addPatternForm">
-    <input id="newPattern" type="text" placeholder="URL pattern" required>
+    <input id="newPattern" type="text" placeholder="https://example.com/path" required>
     <button type="submit">Add</button>
   </form>
 
-  <h2>Time Spent</h2>
-  <table>
-    <thead><tr><th>Domain</th><th>Time</th><th></th></tr></thead>
-    <tbody id="statsList"></tbody>
+  <h2>Focus Sessions</h2>
+  <table id="sessionsTable">
+    <thead>
+      <tr>
+        <th>Days</th><th>Start</th><th>End</th><th>Break (min)</th><th></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
   </table>
+  <button id="addSession">Add Session</button>
 
   <script src="options.js"></script>
 </body>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -4,25 +4,13 @@
   <meta charset="utf-8">
   <title>Stonewall</title>
   <style>
-    body { font-family: sans-serif; width: 250px; }
-    label, select, input, button { display: block; width: 100%; margin: 4px 0; }
+    body { font-family: sans-serif; width: 200px; }
+    button { width: 100%; margin: 4px 0; }
   </style>
 </head>
 <body>
-  <label for="listSelect">List</label>
-  <select id="listSelect"></select>
-  <label for="minutes">Minutes</label>
-  <input id="minutes" type="number" min="1" value="20">
-  <label for="manual">Manual</label>
-  <select id="manual">
-    <option value="">Auto</option>
-    <option value="block">Block</option>
-    <option value="unblock">Unblock</option>
-  </select>
-  <button id="start">Start Pomodoro</button>
-  <button id="end">End Pomodoro</button>
-  <div id="countdown"></div>
-  <div id="status"></div>
+  <div id="state"></div>
+  <button id="toggle"></button>
   <a id="openOptions" href="#">Preferences</a>
   <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- rewrite extension to use single block/allow list with focus sessions and break timers
- allow immediate blocking via popup toggle
- configurable schedules with days of week and break length
- simplified options and popup pages

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685af6d9518883288032c6e2de9719d1