### PR TITLE
Implement break sessions on blocked page

### DIFF
--- a/extension/blocked.html
+++ b/extension/blocked.html
@@ -5,9 +5,11 @@
   <title>URL Blocked</title>
   <link rel="stylesheet" href="stonewall-theme.css">
 </head>
-<body>
+<body class="blocked">
   <p id="msg"></p>
-  <button id="unblock">Unblock</button>
+  <button id="breakBtn">Start Break</button>
+  <div id="progressContainer"><div id="progressBar"></div></div>
+  <div id="breakTimer"></div>
   <script src="blocked.js"></script>
 </body>
 </html>

--- a/extension/blocked.js
+++ b/extension/blocked.js
@@ -1,8 +1,58 @@
+'use strict';
+
 const params = new URLSearchParams(location.search);
 const url = params.get('url') || '';
-document.getElementById('msg').textContent = `The following URL is blocked: ${url}`;
+const msgEl = document.getElementById('msg');
+const btn = document.getElementById('breakBtn');
+const timerEl = document.getElementById('breakTimer');
+const progress = document.getElementById('progressBar');
 
-document.getElementById('unblock').addEventListener('click', () => {
-  browser.runtime.sendMessage({type: 'unblockUrl', url});
-  window.history.back();
-});
+let breakUntil = 0;
+let breakDuration = 0; // ms
+let intervalId = null;
+
+msgEl.textContent = `The following URL is blocked: ${url}`;
+
+function updateTimer() {
+  const now = Date.now();
+  const rem = breakUntil - now;
+  if (rem <= 0) {
+    clearInterval(intervalId);
+    intervalId = null;
+    timerEl.textContent = '';
+    progress.style.width = '0%';
+    btn.disabled = false;
+    breakUntil = 0;
+    return;
+  }
+  const sec = Math.ceil(rem / 1000);
+  timerEl.textContent = `Break ends in ${Math.floor(sec / 60)}m ${sec % 60}s`;
+  if (breakDuration) {
+    const used = breakDuration - rem;
+    const pct = Math.min(100, Math.max(0, (used / breakDuration) * 100));
+    progress.style.width = pct + '%';
+  }
+}
+
+async function startBreak() {
+  const until = await browser.runtime.sendMessage({ type: 'start-break' });
+  const data = await browser.storage.local.get(['breakDuration']);
+  breakDuration = (data.breakDuration || 5) * 60000;
+  breakUntil = until;
+  btn.disabled = true;
+  updateTimer();
+  if (!intervalId) intervalId = setInterval(updateTimer, 1000);
+}
+
+btn.addEventListener('click', startBreak);
+
+(async function init() {
+  const data = await browser.storage.local.get(['breakUntil', 'breakDuration']);
+  breakUntil = data.breakUntil || 0;
+  breakDuration = (data.breakDuration || 5) * 60000;
+  if (breakUntil > Date.now()) {
+    btn.disabled = true;
+    updateTimer();
+    intervalId = setInterval(updateTimer, 1000);
+  }
+})();

--- a/extension/options.html
+++ b/extension/options.html
@@ -14,6 +14,9 @@
     </select>
   </label>
   <label><input id="immediate" type="checkbox"> Immediate Block</label>
+  <label>Default Break (min)
+    <input id="breakDuration" type="number" min="1">
+  </label>
 
   <h2>Patterns</h2>
   <table id="patternsTable">

--- a/extension/options.js
+++ b/extension/options.js
@@ -2,6 +2,7 @@
 
 const modeEl = document.getElementById('mode');
 const immediateEl = document.getElementById('immediate');
+const breakDurationEl = document.getElementById('breakDuration');
 const patternsBody = document.querySelector('#patternsTable tbody');
 const sessionsBody = document.querySelector('#sessionsTable tbody');
 
@@ -10,7 +11,8 @@ let state = {
   patterns: [],
   sessions: [],
   immediate: false,
-  breakUntil: 0
+  breakUntil: 0,
+  breakDuration: 5
 };
 
 async function load() {
@@ -18,6 +20,7 @@ async function load() {
   Object.assign(state, data);
   modeEl.value = state.mode;
   immediateEl.checked = state.immediate;
+  breakDurationEl.value = state.breakDuration;
   renderPatterns();
   renderSessions();
 }
@@ -138,6 +141,11 @@ immediateEl.addEventListener('change', () => {
   save();
 });
 
+breakDurationEl.addEventListener('change', () => {
+  state.breakDuration = parseInt(breakDurationEl.value, 10) || 0;
+  save();
+});
+
 document.getElementById('addPatternForm').addEventListener('submit', (e) => {
   e.preventDefault();
   const val = document.getElementById('newPattern').value.trim();
@@ -161,6 +169,7 @@ browser.storage.onChanged.addListener((changes, area) => {
     }
     modeEl.value = state.mode;
     immediateEl.checked = state.immediate;
+    breakDurationEl.value = state.breakDuration;
     renderPatterns();
     renderSessions();
   }

--- a/extension/stonewall-theme.css
+++ b/extension/stonewall-theme.css
@@ -86,3 +86,33 @@ a:hover {
   padding: 16px;
 }
 
+/* Blocked page layout */
+body.blocked {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  text-align: center;
+}
+
+#breakTimer {
+  margin-top: 8px;
+}
+
+#progressContainer {
+  width: 80%;
+  height: 12px;
+  background-color: #dcdcdc;
+  border-radius: 6px;
+  margin-top: 8px;
+  overflow: hidden;
+}
+
+#progressBar {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(to right, #a8d5ba, #5a9b8e);
+  transition: width 1s linear;
+}
+


### PR DESCRIPTION
## Summary
- center the blocked page content and show break timer/progress
- add a `Start Break` button to temporarily unblock
- make break length configurable in options
- support break functionality in background script

## Testing
- `node --check extension/blocked.js`
- `node --check extension/background.js`
- `node --check extension/options.js`

------
https://chatgpt.com/codex/tasks/task_e_685b164f0fd883288e15afef63e534de