### PR TITLE
Support separate allow and block lists

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -3,7 +3,8 @@
 // Storage keys
 const DEFAULT_STATE = {
   mode: 'block', // 'block' or 'allow'
-  patterns: [], // list of URL patterns
+  blockPatterns: [], // list of URL patterns when in block mode
+  allowPatterns: [], // list of URL patterns when in allow mode
   sessions: [], // [{days:[0-6], start:'HH:MM', end:'HH:MM', break:5}]
   immediate: false, // manual immediate block
   breakUntil: 0,
@@ -42,8 +43,16 @@ async function enforceBlocking() {
 }
 
 async function loadState() {
-  const data = await browser.storage.local.get(Object.keys(DEFAULT_STATE));
+  const data = await browser.storage.local.get([...Object.keys(DEFAULT_STATE), 'patterns']);
   state = Object.assign({}, DEFAULT_STATE, data);
+  // migrate old single pattern list if present
+  if (Array.isArray(data.patterns)) {
+    if (!data.blockPatterns && state.mode === 'block') {
+      state.blockPatterns = data.patterns;
+    } else if (!data.allowPatterns && state.mode === 'allow') {
+      state.allowPatterns = data.patterns;
+    }
+  }
   lastFocus = focusActive();
 
   if (lastFocus) {
@@ -132,6 +141,10 @@ function checkFocusChange() {
   lastFocus = active;
 }
 
+function activePatterns() {
+  return state.mode === 'block' ? state.blockPatterns : state.allowPatterns;
+}
+
 function isBlocked(url) {
   try {
     const scheme = new URL(url).protocol;
@@ -140,7 +153,7 @@ function isBlocked(url) {
     return false;
   }
   if (!focusActive()) return false;
-  const matched = state.patterns.some(p => patternMatches(p, url));
+  const matched = activePatterns().some(p => patternMatches(p, url));
   if (state.mode === 'block') return matched;
   return !matched;
 }
@@ -165,10 +178,10 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 browser.runtime.onMessage.addListener((msg) => {
   if (msg.type === 'unblockUrl' && msg.url) {
     if (state.mode === 'allow') {
-      if (!state.patterns.includes(msg.url)) state.patterns.push(msg.url);
+      if (!state.allowPatterns.includes(msg.url)) state.allowPatterns.push(msg.url);
     } else {
-      const idx = state.patterns.indexOf(msg.url);
-      if (idx !== -1) state.patterns.splice(idx, 1);
+      const idx = state.blockPatterns.indexOf(msg.url);
+      if (idx !== -1) state.blockPatterns.splice(idx, 1);
     }
     return saveState();
   }
@@ -214,6 +227,7 @@ browser.storage.onChanged.addListener((changes, area) => {
     for (const key of Object.keys(changes)) {
       state[key] = changes[key].newValue;
     }
+    restoreTabs();
     enforceBlocking();
     checkFocusChange();
   }

--- a/extension/options.html
+++ b/extension/options.html
@@ -27,7 +27,7 @@
     <button id="optStop" style="display:none;">Stop Break</button>
   </div>
 
-  <h2>Patterns</h2>
+  <h2 id="patternsHeading">Block List</h2>
   <table id="patternsTable">
     <thead><tr><th>URL Pattern</th><th></th></tr></thead>
     <tbody></tbody>

--- a/extension/options.js
+++ b/extension/options.js
@@ -9,10 +9,12 @@ const optStop = document.getElementById('optStop');
 const optQuickBtns = document.querySelectorAll('.optQuick');
 const patternsBody = document.querySelector('#patternsTable tbody');
 const sessionsBody = document.querySelector('#sessionsTable tbody');
+const patternsHeading = document.getElementById('patternsHeading');
 
 let state = {
   mode: 'block',
-  patterns: [],
+  blockPatterns: [],
+  allowPatterns: [],
   sessions: [],
   immediate: false,
   breakUntil: 0,
@@ -26,6 +28,7 @@ async function load() {
   immediateEl.checked = state.immediate;
   breakDurationEl.value = state.breakDuration;
   optBreakInput.value = state.breakDuration;
+  updatePatternsHeading();
   renderPatterns();
   renderSessions();
   updateBreakControls();
@@ -49,9 +52,18 @@ function updateBreakControls() {
   }
 }
 
+function updatePatternsHeading() {
+  patternsHeading.textContent = state.mode === 'block' ? 'Block List' : 'Allow List';
+}
+
+function getActiveList() {
+  return state.mode === 'block' ? state.blockPatterns : state.allowPatterns;
+}
+
 function renderPatterns() {
   patternsBody.innerHTML = '';
-  state.patterns.forEach((p, i) => {
+  const list = getActiveList();
+  list.forEach((p, i) => {
     const tr = document.createElement('tr');
     const tdIn = document.createElement('td');
     const input = document.createElement('input');
@@ -59,9 +71,9 @@ function renderPatterns() {
     input.value = p;
     input.addEventListener('change', () => {
       if (input.value.trim()) {
-        state.patterns[i] = input.value.trim();
+        list[i] = input.value.trim();
       } else {
-        state.patterns.splice(i, 1);
+        list.splice(i, 1);
       }
       save();
       renderPatterns();
@@ -71,7 +83,7 @@ function renderPatterns() {
     const btn = document.createElement('button');
     btn.textContent = 'Remove';
     btn.addEventListener('click', () => {
-      state.patterns.splice(i, 1);
+      list.splice(i, 1);
       save();
       renderPatterns();
     });
@@ -153,7 +165,9 @@ function renderSessions() {
 
 modeEl.addEventListener('change', () => {
   state.mode = modeEl.value;
+  updatePatternsHeading();
   save();
+  renderPatterns();
 });
 
 immediateEl.addEventListener('change', () => {
@@ -187,7 +201,8 @@ document.getElementById('addPatternForm').addEventListener('submit', (e) => {
   e.preventDefault();
   const val = document.getElementById('newPattern').value.trim();
   if (!val) return;
-  state.patterns.push(val);
+  const list = getActiveList();
+  list.push(val);
   document.getElementById('newPattern').value = '';
   save();
   renderPatterns();
@@ -208,6 +223,7 @@ browser.storage.onChanged.addListener((changes, area) => {
     immediateEl.checked = state.immediate;
     breakDurationEl.value = state.breakDuration;
     optBreakInput.value = state.breakDuration;
+    updatePatternsHeading();
     renderPatterns();
     renderSessions();
     updateBreakControls();


### PR DESCRIPTION
## Summary
- maintain `allowPatterns` and `blockPatterns`
- show the correct pattern list in options based on the selected mode
- update heading to clarify which list is active
- restore tabs when storage changes so mode switches unblock pages

## Testing
- `node --check extension/background.js`
- `node --check extension/options.js`
- `node --check extension/blocked.js`

------
https://chatgpt.com/codex/tasks/task_e_685c7fb39dbc8328aed40ef5253e2056