### PR TITLE
Implement website time tracking

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,10 +10,11 @@
     "webNavigation",
     "webRequest",
     "webRequestBlocking",
-    "alarms"
+    "alarms",
+    "idle"
   ],
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js", "timeTracking.js"]
   },
   "icons": {
     "48": "brick.png",

--- a/extension/options.html
+++ b/extension/options.html
@@ -48,6 +48,17 @@
   </table>
   <button id="addSession">Add Session</button>
 
+  <h2>Time Tracking</h2>
+  <table id="usageTable">
+    <thead>
+      <tr>
+        <th>Website</th><th>Total Time</th><th>Last Accessed</th><th></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <canvas id="usageChart" width="400" height="200"></canvas>
+
   <script src="options.js"></script>
 </body>
 </html>

--- a/extension/timeTracking.js
+++ b/extension/timeTracking.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const USAGE_KEY = 'usage';
+let usageData = { totals: {}, sessions: [] };
+let current = null; // {domain, start}
+
+async function loadUsageData() {
+  const data = await browser.storage.local.get(USAGE_KEY);
+  usageData = data[USAGE_KEY] || { totals: {}, sessions: [] };
+}
+
+function saveUsageData() {
+  return browser.storage.local.set({ [USAGE_KEY]: usageData });
+}
+
+function startSession(domain) {
+  if (current && current.domain === domain) return;
+  stopSession();
+  current = { domain, start: Date.now() };
+}
+
+function stopSession() {
+  if (!current) return;
+  const end = Date.now();
+  const dur = end - current.start;
+  let info = usageData.totals[current.domain];
+  if (!info) info = usageData.totals[current.domain] = { total: 0, last: 0 };
+  info.total += dur;
+  info.last = end;
+  usageData.sessions.push({ domain: current.domain, start: current.start, end });
+  current = null;
+  saveUsageData();
+}
+
+function shouldTrack() {
+  if (typeof state !== 'undefined' && state.breakUntil && Date.now() < state.breakUntil) return false;
+  return true;
+}
+
+async function handleActiveTab(tabId) {
+  if (!shouldTrack()) { stopSession(); return; }
+  try {
+    const tab = await browser.tabs.get(tabId);
+    if (!tab.active) return;
+    const url = tab.url || '';
+    const domain = new URL(url).hostname;
+    startSession(domain);
+  } catch (e) {
+    stopSession();
+  }
+}
+
+browser.tabs.onActivated.addListener(info => handleActiveTab(info.tabId));
+
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tab.active && changeInfo.url) {
+    handleActiveTab(tabId);
+  }
+});
+
+browser.windows.onFocusChanged.addListener(winId => {
+  if (winId === browser.windows.WINDOW_ID_NONE) {
+    stopSession();
+  } else {
+    browser.tabs.query({ active: true, windowId: winId }).then(tabs => {
+      if (tabs.length) handleActiveTab(tabs[0].id); else stopSession();
+    });
+  }
+});
+
+browser.idle.onStateChanged.addListener(state => {
+  if (state === 'active') {
+    browser.tabs.query({ active: true, currentWindow: true }).then(tabs => {
+      if (tabs.length) handleActiveTab(tabs[0].id);
+    });
+  } else {
+    stopSession();
+  }
+});
+
+browser.runtime.onMessage.addListener(msg => {
+  if (msg.type === 'start-break') stopSession();
+});
+
+loadUsageData().then(() => {
+  browser.tabs.query({ active: true, currentWindow: true }).then(tabs => {
+    if (tabs.length) handleActiveTab(tabs[0].id);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `timeTracking.js` background script to monitor active tabs
- extend options page with usage table and chart
- support usage persistence and removal
- load usage state in options page and render UI
- include `idle` permission in manifest

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686002308d5c8328b0a6eb1cee108e8b