### PR TITLE
Add access count and sorting

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -52,7 +52,11 @@
   <table id="usageTable">
     <thead>
       <tr>
-        <th>Website</th><th>Total Time</th><th>Last Accessed</th><th></th>
+        <th>Website</th>
+        <th id="sortTime" class="sortable">Total Time</th>
+        <th>Last Accessed</th>
+        <th id="sortCount" class="sortable">Access Count</th>
+        <th></th>
       </tr>
     </thead>
     <tbody></tbody>

--- a/extension/options.js
+++ b/extension/options.js
@@ -12,6 +12,10 @@ const sessionsBody = document.querySelector('#sessionsTable tbody');
 const patternsHeading = document.getElementById('patternsHeading');
 const usageBody = document.querySelector('#usageTable tbody');
 const usageChart = document.getElementById('usageChart');
+const sortTimeHead = document.getElementById('sortTime');
+const sortCountHead = document.getElementById('sortCount');
+
+let usageSort = 'time';
 
 let state = {
   mode: 'block',
@@ -181,7 +185,11 @@ function formatDuration(ms) {
 function renderUsage() {
   usageBody.innerHTML = '';
   const entries = Object.entries(usage.totals);
-  entries.sort((a, b) => b[1].total - a[1].total);
+  if (usageSort === 'count') {
+    entries.sort((a, b) => (b[1].count || 0) - (a[1].count || 0));
+  } else {
+    entries.sort((a, b) => b[1].total - a[1].total);
+  }
   entries.slice(0, 10).forEach(([domain, info]) => {
     const tr = document.createElement('tr');
     const tdDom = document.createElement('td');
@@ -190,6 +198,8 @@ function renderUsage() {
     tdTotal.textContent = formatDuration(info.total);
     const tdLast = document.createElement('td');
     tdLast.textContent = new Date(info.last).toLocaleString();
+    const tdCount = document.createElement('td');
+    tdCount.textContent = info.count || 0;
     const tdAct = document.createElement('td');
     const btn = document.createElement('button');
     btn.textContent = 'Remove';
@@ -198,6 +208,7 @@ function renderUsage() {
     tr.appendChild(tdDom);
     tr.appendChild(tdTotal);
     tr.appendChild(tdLast);
+    tr.appendChild(tdCount);
     tr.appendChild(tdAct);
     usageBody.appendChild(tr);
   });
@@ -345,6 +356,17 @@ document.getElementById('addSession').addEventListener('click', () => {
   save();
   renderSessions();
 });
+
+if (sortTimeHead && sortCountHead) {
+  sortTimeHead.addEventListener('click', () => {
+    usageSort = 'time';
+    renderUsage();
+  });
+  sortCountHead.addEventListener('click', () => {
+    usageSort = 'count';
+    renderUsage();
+  });
+}
 
 browser.storage.onChanged.addListener((changes, area) => {
   if (area === 'local') {

--- a/extension/stonewall-theme.css
+++ b/extension/stonewall-theme.css
@@ -47,6 +47,10 @@ td, th {
   padding: 4px 8px;
 }
 
+th.sortable {
+  cursor: pointer;
+}
+
 input[type="text"],
 input[type="time"],
 select {

--- a/extension/timeTracking.js
+++ b/extension/timeTracking.js
@@ -7,6 +7,9 @@ let current = null; // {domain, start}
 async function loadUsageData() {
   const data = await browser.storage.local.get(USAGE_KEY);
   usageData = data[USAGE_KEY] || { totals: {}, sessions: [] };
+  for (const info of Object.values(usageData.totals)) {
+    if (!Object.prototype.hasOwnProperty.call(info, 'count')) info.count = 0;
+  }
 }
 
 function saveUsageData() {
@@ -16,7 +19,13 @@ function saveUsageData() {
 function startSession(domain) {
   if (current && current.domain === domain) return;
   stopSession();
-  current = { domain, start: Date.now() };
+  const now = Date.now();
+  let info = usageData.totals[domain];
+  if (!info) info = usageData.totals[domain] = { total: 0, last: 0, count: 0 };
+  if (!info.last || now - info.last >= 30000) {
+    info.count += 1;
+  }
+  current = { domain, start: now };
 }
 
 function stopSession() {
@@ -24,7 +33,7 @@ function stopSession() {
   const end = Date.now();
   const dur = end - current.start;
   let info = usageData.totals[current.domain];
-  if (!info) info = usageData.totals[current.domain] = { total: 0, last: 0 };
+  if (!info) info = usageData.totals[current.domain] = { total: 0, last: 0, count: 0 };
   info.total += dur;
   info.last = end;
   usageData.sessions.push({ domain: current.domain, start: current.start, end });


### PR DESCRIPTION
## Summary
- track access count per website
- show access count column in usage table
- allow sorting by total time or access count
- style sortable columns

## Testing
- `node --check extension/options.js`
- `node --check extension/timeTracking.js`


------
https://chatgpt.com/codex/tasks/task_e_68628ec607d08328a08ae7aa6e59b9cc