### PR TITLE
Fix reload loop for blocked URLs

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -166,6 +166,19 @@ browser.webNavigation.onCommitted.addListener(details => {
   }
 });
 
+// Intercept requests before they are made to avoid reload loops
+browser.webRequest.onBeforeRequest.addListener(
+  details => {
+    if (isBlocked(details.url)) {
+      const blockedUrl = browser.runtime.getURL('blocked.html') +
+        '?url=' + encodeURIComponent(details.url);
+      return { redirectUrl: blockedUrl };
+    }
+  },
+  { urls: ['<all_urls>'], types: ['main_frame'] },
+  ['blocking']
+);
+
 // Some sites update the URL without a full navigation (e.g. via the history
 // API). Listen for tab updates so we catch those changes as well as normal
 // loads.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,6 +10,7 @@
     "webNavigation",
     "webRequest",
     "webRequestBlocking",
+    "<all_urls>",
     "alarms",
     "idle"
   ],


### PR DESCRIPTION
## Summary
- intercept requests before they're sent to avoid reload loops
- add `<all_urls>` host permission for webRequest usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68659affe85c83288acdc8fd28479d6b