### PR TITLE
feat: add break delay countdown

### DIFF
--- a/extension/blocked.html
+++ b/extension/blocked.html
@@ -18,6 +18,14 @@
   <button id="stopBreakBtn" style="display:none;">Stop Break</button>
   <div id="progressContainer"><div id="progressBar"></div></div>
   <div id="breakTimer"></div>
+  <div id="countdownOverlay" style="display:none;">
+    <div id="delayMessage" aria-live="polite">Please wait 15 seconds…</div>
+    <div id="delayTimer" aria-live="polite">15 seconds remaining</div>
+    <div class="buttonRow">
+      <button id="cancelDelay">Cancel</button>
+      <button id="continueDelay" disabled>Continue</button>
+    </div>
+  </div>
   <script src="blocked.js"></script>
 </body>
 </html>

--- a/extension/blocked.js
+++ b/extension/blocked.js
@@ -9,10 +9,16 @@ const timerEl = document.getElementById('breakTimer');
 const progress = document.getElementById('progressBar');
 const durInput = document.getElementById('durationInput');
 const quickBtns = document.querySelectorAll('.quickBreak');
+const countdown = document.getElementById('countdownOverlay');
+const delayTimer = document.getElementById('delayTimer');
+const cancelDelay = document.getElementById('cancelDelay');
+const continueDelay = document.getElementById('continueDelay');
 
 let breakUntil = 0;
 let breakDuration = 0; // ms
 let intervalId = null;
+let delayInterval = null;
+let pendingDuration = 0;
 
 msgEl.textContent = `The following URL is blocked: ${url}`;
 
@@ -62,9 +68,43 @@ async function stopBreak() {
   updateTimer();
 }
 
-btn.addEventListener('click', () => startBreak());
+function hideDelay() {
+  if (delayInterval) {
+    clearInterval(delayInterval);
+    delayInterval = null;
+  }
+  countdown.style.display = 'none';
+}
+
+function showDelay(duration) {
+  hideDelay();
+  pendingDuration = duration || parseInt(durInput.value, 10) || 5;
+  let remaining = 15;
+  delayTimer.textContent = `${remaining} seconds remaining`;
+  countdown.style.display = 'block';
+  continueDelay.disabled = true;
+  delayInterval = setInterval(() => {
+    remaining -= 1;
+    if (remaining > 0) {
+      delayTimer.textContent = `${remaining} seconds remaining`;
+    } else {
+      clearInterval(delayInterval);
+      delayInterval = null;
+      delayTimer.textContent = 'Ready';
+      continueDelay.disabled = false;
+    }
+  }, 1000);
+}
+
+cancelDelay.addEventListener('click', () => hideDelay());
+continueDelay.addEventListener('click', () => {
+  hideDelay();
+  startBreak(pendingDuration);
+});
+
+btn.addEventListener('click', () => showDelay());
 quickBtns.forEach(b => {
-  b.addEventListener('click', () => startBreak(parseInt(b.dataset.duration,10)));
+  b.addEventListener('click', () => showDelay(parseInt(b.dataset.duration,10)));
 });
 stopBtn.addEventListener('click', stopBreak);
 

--- a/extension/stonewall-theme.css
+++ b/extension/stonewall-theme.css
@@ -116,3 +116,23 @@ body.blocked {
   transition: width 1s linear;
 }
 
+/* Countdown overlay for break delay */
+#countdownOverlay {
+  margin-top: 16px;
+}
+
+#delayTimer {
+  font-size: 24px;
+  margin: 8px 0;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.buttonRow button {
+  flex: 1;
+}
+


### PR DESCRIPTION
## Summary
- add 15-second break request countdown with cancel/continue controls
- disable continue until delay expires and allow cancel anytime
- style new countdown UI

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b970973808328ad4d142441f383e5