### PR TITLE
feat: add block exception patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Open the extension options page to configure blocking rules.
 - **Mode** – choose between blocking listed URLs or allowing only the listed URLs.
 - **Immediate Block** – manually enable or disable blocking regardless of schedules.
 - **Patterns** – list of full URLs or domains to block or allow.
+- **Block Exceptions** – allowed URLs or paths within blocked sites (only in Block mode).
 - **Focus Sessions** – set days of the week, start and end times, and break lengths. When a session ends the break timer unblocks pages for the specified minutes.
 
 Use the toolbar popup to quickly toggle immediate blocking or open the options page.

--- a/background/background.js
+++ b/background/background.js
@@ -5,6 +5,7 @@ const DEFAULT_STATE = {
   mode: 'block', // 'block' or 'allow'
   blockPatterns: [], // list of URL patterns when in block mode
   allowPatterns: [], // list of URL patterns when in allow mode
+  exceptionPatterns: [], // list of exception patterns within blocked URLs
   sessions: [], // [{days:[0-6], start:'HH:MM', end:'HH:MM', break:5}]
   immediate: false, // manual immediate block
   breakUntil: 0,
@@ -141,10 +142,6 @@ function checkFocusChange() {
   lastFocus = active;
 }
 
-function activePatterns() {
-  return state.mode === 'block' ? state.blockPatterns : state.allowPatterns;
-}
-
 function isBlocked(url) {
   try {
     const scheme = new URL(url).protocol;
@@ -153,8 +150,13 @@ function isBlocked(url) {
     return false;
   }
   if (!focusActive()) return false;
-  const matched = activePatterns().some(p => patternMatches(p, url));
-  if (state.mode === 'block') return matched;
+  if (state.mode === 'block') {
+    const matched = state.blockPatterns.some(p => patternMatches(p, url));
+    if (!matched) return false;
+    const exceptionMatched = state.exceptionPatterns.some(p => patternMatches(p, url));
+    return !exceptionMatched;
+  }
+  const matched = state.allowPatterns.some(p => patternMatches(p, url));
   return !matched;
 }
 

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -37,6 +37,19 @@
     <button type="submit">Add</button>
   </form>
 
+  <div id="exceptionsSection" style="display:none;">
+    <h2>Block Exceptions</h2>
+    <table id="exceptionsTable">
+      <thead><tr><th>URL Pattern</th><th></th></tr></thead>
+      <tbody></tbody>
+    </table>
+    <form id="addExceptionForm">
+      <input id="newException" type="text" placeholder="reddit.com/r/programming" required>
+      <button type="submit">Add</button>
+    </form>
+    <p class="patternHelp">Patterns match a domain and optional path. Example: reddit.com/r/programming</p>
+  </div>
+
   <h2>Focus Sessions</h2>
   <table id="sessionsTable">
     <thead>

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -8,6 +8,8 @@ const optStart = document.getElementById('optStart');
 const optStop = document.getElementById('optStop');
 const optQuickBtns = document.querySelectorAll('.optQuick');
 const patternsBody = document.querySelector('#patternsTable tbody');
+const exceptionsSection = document.getElementById('exceptionsSection');
+const exceptionsBody = document.querySelector('#exceptionsTable tbody');
 const sessionsBody = document.querySelector('#sessionsTable tbody');
 const patternsHeading = document.getElementById('patternsHeading');
 
@@ -15,6 +17,7 @@ let state = {
   mode: 'block',
   blockPatterns: [],
   allowPatterns: [],
+  exceptionPatterns: [],
   sessions: [],
   immediate: false,
   breakUntil: 0,
@@ -30,8 +33,10 @@ async function load() {
   optBreakInput.value = state.breakDuration;
   updatePatternsHeading();
   renderPatterns();
+  renderExceptions();
   renderSessions();
   updateBreakControls();
+  updateExceptionsVisibility();
 }
 
 function save() {
@@ -58,6 +63,12 @@ function updatePatternsHeading() {
 
 function getActiveList() {
   return state.mode === 'block' ? state.blockPatterns : state.allowPatterns;
+}
+
+function updateExceptionsVisibility() {
+  if (exceptionsSection) {
+    exceptionsSection.style.display = state.mode === 'block' ? 'block' : 'none';
+  }
 }
 
 function renderPatterns() {
@@ -91,6 +102,39 @@ function renderPatterns() {
     tr.appendChild(tdIn);
     tr.appendChild(tdAct);
     patternsBody.appendChild(tr);
+  });
+}
+
+function renderExceptions() {
+  exceptionsBody.innerHTML = '';
+  state.exceptionPatterns.forEach((p, i) => {
+    const tr = document.createElement('tr');
+    const tdIn = document.createElement('td');
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = p;
+    input.addEventListener('change', () => {
+      if (input.value.trim()) {
+        state.exceptionPatterns[i] = input.value.trim();
+      } else {
+        state.exceptionPatterns.splice(i, 1);
+      }
+      save();
+      renderExceptions();
+    });
+    tdIn.appendChild(input);
+    const tdAct = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Remove';
+    btn.addEventListener('click', () => {
+      state.exceptionPatterns.splice(i, 1);
+      save();
+      renderExceptions();
+    });
+    tdAct.appendChild(btn);
+    tr.appendChild(tdIn);
+    tr.appendChild(tdAct);
+    exceptionsBody.appendChild(tr);
   });
 }
 
@@ -168,6 +212,8 @@ modeEl.addEventListener('change', () => {
   updatePatternsHeading();
   save();
   renderPatterns();
+  renderExceptions();
+  updateExceptionsVisibility();
 });
 
 immediateEl.addEventListener('change', () => {
@@ -208,6 +254,16 @@ document.getElementById('addPatternForm').addEventListener('submit', (e) => {
   renderPatterns();
 });
 
+document.getElementById('addExceptionForm').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const val = document.getElementById('newException').value.trim();
+  if (!val) return;
+  state.exceptionPatterns.push(val);
+  document.getElementById('newException').value = '';
+  save();
+  renderExceptions();
+});
+
 document.getElementById('addSession').addEventListener('click', () => {
   state.sessions.push({days: [1,2,3,4,5], start: '09:00', end: '17:00', break: 5});
   save();
@@ -225,8 +281,10 @@ browser.storage.onChanged.addListener((changes, area) => {
     optBreakInput.value = state.breakDuration;
     updatePatternsHeading();
     renderPatterns();
+    renderExceptions();
     renderSessions();
     updateBreakControls();
+    updateExceptionsVisibility();
   }
 });
 


### PR DESCRIPTION
## Summary
- allow specifying exception URL patterns that bypass blocking
- provide UI on options page to manage exception list
- document exceptions feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689214d6dbbc8328a1df5e01ffafe842