### PR TITLE
feat: add one-click exception buttons

### DIFF
--- a/pages/blocked/blocked.html
+++ b/pages/blocked/blocked.html
@@ -16,6 +16,8 @@
   </div>
   <button id="breakBtn">Start Break</button>
   <button id="stopBreakBtn" style="display:none;">Stop Break</button>
+  <button id="addExceptionBtn">Add to Exception List</button>
+  <div id="blockedExceptionMsg" aria-live="polite"></div>
   <div id="progressContainer"><div id="progressBar"></div></div>
   <div id="breakTimer"></div>
   <div id="countdownOverlay" style="display:none;">

--- a/pages/blocked/blocked.js
+++ b/pages/blocked/blocked.js
@@ -13,12 +13,16 @@ const countdown = document.getElementById('countdownOverlay');
 const delayTimer = document.getElementById('delayTimer');
 const cancelDelay = document.getElementById('cancelDelay');
 const continueDelay = document.getElementById('continueDelay');
+const addExcBtn = document.getElementById('addExceptionBtn');
+const excMsg = document.getElementById('blockedExceptionMsg');
 
 let breakUntil = 0;
 let breakDuration = 0; // ms
 let intervalId = null;
 let delayInterval = null;
 let pendingDuration = 0;
+let mode = 'block';
+let exceptionPatterns = [];
 
 msgEl.textContent = `The following URL is blocked: ${url}`;
 
@@ -107,12 +111,56 @@ quickBtns.forEach(b => {
   b.addEventListener('click', () => showDelay(parseInt(b.dataset.duration,10)));
 });
 stopBtn.addEventListener('click', stopBreak);
+addExcBtn.addEventListener('click', async () => {
+  const pattern = normalizeUrl(url);
+  const data = await browser.storage.local.get(['exceptionPatterns']);
+  const list = data.exceptionPatterns || [];
+  if (!list.includes(pattern)) {
+    list.push(pattern);
+    await browser.storage.local.set({exceptionPatterns: list});
+    excMsg.textContent = 'URL added to exceptions';
+    setTimeout(() => { excMsg.textContent = ''; }, 2000);
+    exceptionPatterns = list;
+    updateExceptionButton();
+    setTimeout(() => { location.href = url; }, 500);
+  }
+});
+
+function normalizeUrl(u) {
+  try {
+    const x = new URL(u);
+    return x.origin + x.pathname;
+  } catch (e) {
+    return u;
+  }
+}
+
+function updateExceptionButton() {
+  if (!addExcBtn) return;
+  if (mode !== 'block' || !url) {
+    addExcBtn.style.display = 'none';
+    return;
+  }
+  addExcBtn.style.display = 'inline-block';
+  const pattern = normalizeUrl(url);
+  const exists = exceptionPatterns.includes(pattern);
+  if (exists) {
+    addExcBtn.textContent = 'Already in Exception List';
+    addExcBtn.disabled = true;
+  } else {
+    addExcBtn.textContent = 'Add to Exception List';
+    addExcBtn.disabled = false;
+  }
+}
 
 (async function init() {
-  const data = await browser.storage.local.get(['breakUntil', 'breakDuration','resumeUrl']);
+  const data = await browser.storage.local.get(['breakUntil', 'breakDuration','resumeUrl','mode','exceptionPatterns']);
   breakUntil = data.breakUntil || 0;
   breakDuration = (data.breakDuration || 5) * 60000;
   durInput.value = data.breakDuration || 5;
+  mode = data.mode || 'block';
+  exceptionPatterns = data.exceptionPatterns || [];
+  updateExceptionButton();
   if (breakUntil > Date.now()) {
     btn.disabled = true;
     durInput.disabled = true;
@@ -122,3 +170,11 @@ stopBtn.addEventListener('click', stopBreak);
     intervalId = setInterval(updateTimer, 1000);
   }
 })();
+
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local') {
+    if (changes.mode) mode = changes.mode.newValue;
+    if (changes.exceptionPatterns) exceptionPatterns = changes.exceptionPatterns.newValue;
+    updateExceptionButton();
+  }
+});

--- a/pages/popup/popup.html
+++ b/pages/popup/popup.html
@@ -11,6 +11,8 @@
 <body>
   <div id="state"></div>
   <button id="toggle"></button>
+  <button id="addException">Add to Exception List</button>
+  <div id="exceptionMsg" aria-live="polite"></div>
   <div>
     <label>Break (min)
       <input id="popupDuration" type="number" min="1">

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -7,17 +7,26 @@ const durInput = document.getElementById('popupDuration');
 const startBtn = document.getElementById('popupStart');
 const stopBtn = document.getElementById('popupStop');
 const quickBtns = document.querySelectorAll('.popupQuick');
+const exceptionBtn = document.getElementById('addException');
+const exceptionMsg = document.getElementById('exceptionMsg');
 
 let state = {
   immediate: false,
-  breakUntil: 0
+  breakUntil: 0,
+  mode: 'block',
+  exceptionPatterns: []
 };
 
+let currentUrl = '';
+
 async function load() {
-  const data = await browser.storage.local.get(['immediate','breakUntil','breakDuration']);
+  const data = await browser.storage.local.get(['immediate','breakUntil','breakDuration','mode','exceptionPatterns']);
   Object.assign(state, data);
   durInput.value = data.breakDuration || 5;
+  const tabs = await browser.tabs.query({active:true, currentWindow:true});
+  currentUrl = tabs[0] ? tabs[0].url : '';
   update();
+  updateExceptionButton();
 }
 
 function update() {
@@ -83,12 +92,59 @@ optionsLink.addEventListener('click', (e) => {
   browser.runtime.openOptionsPage();
 });
 
+function normalizeUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.origin + u.pathname;
+  } catch (e) {
+    return url;
+  }
+}
+
+function updateExceptionButton() {
+  if (!exceptionBtn) return;
+  if (state.mode !== 'block' || !currentUrl) {
+    exceptionBtn.style.display = 'none';
+    return;
+  }
+  exceptionBtn.style.display = 'block';
+  const pattern = normalizeUrl(currentUrl);
+  const exists = state.exceptionPatterns.includes(pattern);
+  if (exists) {
+    exceptionBtn.textContent = 'Already in Exception List';
+    exceptionBtn.disabled = true;
+  } else {
+    exceptionBtn.textContent = 'Add to Exception List';
+    exceptionBtn.disabled = false;
+  }
+}
+
+exceptionBtn.addEventListener('click', async () => {
+  if (!currentUrl) return;
+  const pattern = normalizeUrl(currentUrl);
+  const data = await browser.storage.local.get(['exceptionPatterns']);
+  const list = data.exceptionPatterns || [];
+  if (!list.includes(pattern)) {
+    list.push(pattern);
+    await browser.storage.local.set({exceptionPatterns: list});
+    exceptionMsg.textContent = 'URL added to exceptions';
+    setTimeout(() => { exceptionMsg.textContent = ''; }, 2000);
+    state.exceptionPatterns = list;
+    updateExceptionButton();
+    const tabs = await browser.tabs.query({active:true, currentWindow:true});
+    if (tabs[0]) browser.tabs.update(tabs[0].id, {url: currentUrl});
+  }
+});
+
 browser.storage.onChanged.addListener((changes, area) => {
   if (area === 'local') {
     if (changes.immediate) state.immediate = changes.immediate.newValue;
     if (changes.breakUntil) state.breakUntil = changes.breakUntil.newValue;
     if (changes.breakDuration) durInput.value = changes.breakDuration.newValue;
+    if (changes.mode) state.mode = changes.mode.newValue;
+    if (changes.exceptionPatterns) state.exceptionPatterns = changes.exceptionPatterns.newValue;
     update();
+    updateExceptionButton();
   }
 });
 


### PR DESCRIPTION
## Summary
- Add "Add to Exception List" button in popup for quickly whitelisting current site
- Provide same button on blocked page with auto-redirect after adding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c22094e4832889b52eaf764c69b9