### PR TITLE
Support wildcard exceptions and add default Reddit pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Open the extension options page to configure blocking rules.
 - **Immediate Block** – manually enable or disable blocking regardless of schedules.
 - **Patterns** – list of full URLs or domains to block or allow.
 - **Block Exceptions** – allowed URLs or paths within blocked sites (only in Block mode).
+  Wildcards (`*`) are supported in patterns to match variable segments, e.g. `reddit.com/r/*/comments/`.
 - **Focus Sessions** – set days of the week, start and end times, and break lengths. When a session ends the break timer unblocks pages for the specified minutes.
 
 Use the toolbar popup to quickly toggle immediate blocking or open the options page.

--- a/background/background.js
+++ b/background/background.js
@@ -5,7 +5,7 @@ const DEFAULT_STATE = {
   mode: 'block', // 'block' or 'allow'
   blockPatterns: [], // list of URL patterns when in block mode
   allowPatterns: [], // list of URL patterns when in allow mode
-  exceptionPatterns: [], // list of exception patterns within blocked URLs
+  exceptionPatterns: ['reddit.com/r/*/comments/'], // list of exception patterns within blocked URLs
   sessions: [], // [{days:[0-6], start:'HH:MM', end:'HH:MM', break:5}]
   immediate: false, // manual immediate block
   breakUntil: 0,
@@ -68,18 +68,38 @@ function saveState() {
   return browser.storage.local.set(state);
 }
 
+function escapeRegex(str) {
+  return str.replace(/[|\\{}()\[\]^$+*?.]/g, '\$&');
+}
+
+function wildcardRegex(pattern, end = false, flags = '') {
+  const escaped = pattern
+    .split('*')
+    .map(escapeRegex)
+    .join('.*');
+  return new RegExp('^' + escaped + (end ? '$' : ''), flags);
+}
+
 function patternMatches(pattern, url) {
   try {
     const u = new URL(url);
     if (pattern.includes('://')) {
-      return url.startsWith(pattern);
+      return wildcardRegex(pattern).test(url);
     }
     const idx = pattern.indexOf('/');
     const domain = idx === -1 ? pattern : pattern.slice(0, idx);
     const path = idx === -1 ? '' : pattern.slice(idx);
-    if (u.hostname === domain || u.hostname.endsWith('.' + domain)) {
-      return u.pathname.startsWith(path);
+
+    let domainMatched = false;
+    if (domain.includes('*')) {
+      domainMatched = wildcardRegex(domain, true, 'i').test(u.hostname);
+    } else {
+      domainMatched = u.hostname === domain || u.hostname.endsWith('.' + domain);
     }
+    if (!domainMatched) return false;
+
+    if (!path) return true;
+    return wildcardRegex(path).test(u.pathname);
   } catch (e) {
     // ignore
   }

--- a/pages/blocked/blocked.js
+++ b/pages/blocked/blocked.js
@@ -22,7 +22,7 @@ let intervalId = null;
 let delayInterval = null;
 let pendingDuration = 0;
 let mode = 'block';
-let exceptionPatterns = [];
+let exceptionPatterns = ['reddit.com/r/*/comments/'];
 
 msgEl.textContent = `The following URL is blocked: ${url}`;
 

--- a/pages/options/options.html
+++ b/pages/options/options.html
@@ -44,10 +44,10 @@
       <tbody></tbody>
     </table>
     <form id="addExceptionForm">
-      <input id="newException" type="text" placeholder="reddit.com/r/programming" required>
+      <input id="newException" type="text" placeholder="reddit.com/r/*/comments/" required>
       <button type="submit">Add</button>
     </form>
-    <p class="patternHelp">Patterns match a domain and optional path. Example: reddit.com/r/programming</p>
+    <p class="patternHelp">Patterns match a domain and optional path. Use * as a wildcard. Example: reddit.com/r/*/comments/</p>
   </div>
 
   <h2>Focus Sessions</h2>

--- a/pages/options/options.js
+++ b/pages/options/options.js
@@ -17,7 +17,7 @@ let state = {
   mode: 'block',
   blockPatterns: [],
   allowPatterns: [],
-  exceptionPatterns: [],
+  exceptionPatterns: ['reddit.com/r/*/comments/'],
   sessions: [],
   immediate: false,
   breakUntil: 0,

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -14,7 +14,7 @@ let state = {
   immediate: false,
   breakUntil: 0,
   mode: 'block',
-  exceptionPatterns: []
+  exceptionPatterns: ['reddit.com/r/*/comments/']
 };
 
 let currentUrl = '';


### PR DESCRIPTION
## Summary
- allow `*` wildcards in URL pattern matching and exception filtering
- add default exception for `reddit.com/r/*/comments/`
- document wildcard support in options UI and README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689651c460e48328808749eb1a5cf27e